### PR TITLE
Show all emoji candidates.

### DIFF
--- a/rplugin/python3/deoplete/sources/emoji.py
+++ b/rplugin/python3/deoplete/sources/emoji.py
@@ -21,7 +21,7 @@ class Source(Base):
         self.mark = '[emoji]'
         self.matchers = ['matcher_length', 'matcher_full_fuzzy']
         self.name = 'emoji'
-        sels.max_candidates = 0
+        self.max_candidates = 0
 
     def gather_candidates(self, context):
         return [{'word': k, 'kind': ' {} '.format(v)} for (k, v) in EMOJI_CODES.items()]

--- a/rplugin/python3/deoplete/sources/emoji.py
+++ b/rplugin/python3/deoplete/sources/emoji.py
@@ -21,6 +21,7 @@ class Source(Base):
         self.mark = '[emoji]'
         self.matchers = ['matcher_length', 'matcher_full_fuzzy']
         self.name = 'emoji'
+        sels.max_candidates = 0
 
     def gather_candidates(self, context):
         return [{'word': k, 'kind': ' {} '.format(v)} for (k, v) in EMOJI_CODES.items()]


### PR DESCRIPTION
All emoji candidates excess 500 but max_candidates of deoplete is 500 by default. Therefore, you should set max_candidates to 0 or less to show all candidates.
See `:h deoplete-source-attribute-max_candidates` for details.

- Before
![screenshot from 2018-06-20 23-28-33_k](https://user-images.githubusercontent.com/38746469/41665113-2ebc6492-74e2-11e8-8fda-6adc0b4d165e.png)
- After
![screenshot from 2018-06-20 23-30-32_k](https://user-images.githubusercontent.com/38746469/41665139-3b9b4c28-74e2-11e8-9317-34f6a171e151.png)
