### PR TITLE
Insert emojis

### DIFF
--- a/doc/deoplete_emoji.txt
+++ b/doc/deoplete_emoji.txt
@@ -28,6 +28,13 @@ for this source.
 <
 Default: ['gitcommit', 'markdown']
 
+By default, selecting a suggestion from the pop-up will insert a text
+representation of the emoji.  To insert the actual emoji, ensure that your
+terminal supports emoji fonts and that a suitable font is installed. Once that's
+done, enable the `converter_emoji` converter like this:
+
+  `call deoplete#custom#source('emoji', 'converters', ['converter_emoji'])`
+
 ==============================================================================
 LICENSE                                               *deoplete-emoji-license*
 

--- a/rplugin/python3/deoplete/filter/converter_emoji.py
+++ b/rplugin/python3/deoplete/filter/converter_emoji.py
@@ -1,0 +1,29 @@
+# ============================================================================
+# FILE: converter_emoji.py
+# AUTHOR: Adam Macumber <atom.mac at gmail.com>
+# License: MIT license
+# ============================================================================
+
+import re
+
+from deoplete.filter.base import Base
+
+
+class Filter(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'converter_emoji'
+        self.description = 'convert candidates to unicodes'
+        self._cache = {}
+
+    def filter(self, context):
+        def convert(x):
+            word = x['kind'].strip()
+            kind = x['word'].strip()
+            return { 'word': word, 'kind': kind }
+
+        return list(map(convert, context['candidates']))
+
+

--- a/rplugin/python3/deoplete/sources/emoji.py
+++ b/rplugin/python3/deoplete/sources/emoji.py
@@ -20,7 +20,6 @@ class Source(Base):
         self.filetypes = ['gitcommit', 'markdown']
         self.mark = '[emoji]'
         self.matchers = ['matcher_length', 'matcher_full_fuzzy']
-        self.converters = ['converter_emoji']
         self.name = 'emoji'
         self.max_candidates = 0
 

--- a/rplugin/python3/deoplete/sources/emoji.py
+++ b/rplugin/python3/deoplete/sources/emoji.py
@@ -20,6 +20,7 @@ class Source(Base):
         self.filetypes = ['gitcommit', 'markdown']
         self.mark = '[emoji]'
         self.matchers = ['matcher_length', 'matcher_full_fuzzy']
+        self.converters = ['converter_emoji']
         self.name = 'emoji'
         self.max_candidates = 0
 


### PR DESCRIPTION
Provides a new `converter` that allows emojis to be inserted directly instead of just inserting the :emoji_code: text.